### PR TITLE
Update vcr.c

### DIFF
--- a/main/vcr.c
+++ b/main/vcr.c
@@ -452,7 +452,7 @@ static void write_movie_header(FILE * file, int numBytes)
 
 void flush_movie()
 {
-	if(m_file && (m_task == Recording || m_task == StartRecording || m_task == StartRecordingFromSnapshot))
+	if(m_file && (m_task == Recording || m_task != StartRecording || m_task != StartRecordingFromSnapshot))
 	{
 		// (over-)write the header
 	    write_movie_header(m_file, MUP_HEADER_SIZE);

--- a/main/vcr.c
+++ b/main/vcr.c
@@ -1433,7 +1433,7 @@ VCR_stopPlayback()
 		m_inputBufferSize = 0;
 	}
 
-	if (m_file)
+	if (m_file || m_task == StartRecording || m_task == Recording)
 	{
 		fclose( m_file );
 		m_file = 0;


### PR DESCRIPTION
Crash fix - VCR_stopPlayback and VCR_stopRecord both are closing file, so VCR_stopRecord tries to close null handle.