### PR TITLE
Stop recording crash fix

### DIFF
--- a/main/vcr.c
+++ b/main/vcr.c
@@ -1433,7 +1433,7 @@ VCR_stopPlayback()
 		m_inputBufferSize = 0;
 	}
 
-	if (m_file)
+	if (m_file && m_task != StartRecording && m_task != Recording)
 	{
 		fclose( m_file );
 		m_file = 0;


### PR DESCRIPTION
Crash fix - both VCR_stopPlayback and VCR_stopRecord were trying to close a file, so VCR_stopRecord ended up trying to close a null handle.